### PR TITLE
Don't initialize git if we're already in a repo

### DIFF
--- a/huspenders
+++ b/huspenders
@@ -99,7 +99,11 @@ fi
 
 compile_template Main.hs "src/Main.hs"
 compile_template Package.hs "src/${packagename}.hs"
-git_init
+
+if ! git rev-parse --git-dir &>/dev/null; then
+  git_init
+fi
+
 install_and_precompile $generate_hspec
 
 print "${fg_bold[green]}cd $packagename, edit src/Main.hs, run it with \`cabal run\`${reset_color}"


### PR DESCRIPTION
If we're already in a git repo, initializing a new repo _probably_ isn't
what you want to do. If it is, I think it's fair to assume you'll do it
manually.

To that end, I think it's reasonable to only run `git init` if we're
currently _not_ in a git repo.
