### PR TITLE
Don't import the package in Main.hs

### DIFF
--- a/templates/Main.hs
+++ b/templates/Main.hs
@@ -1,5 +1,3 @@
 module Main where
 
-import {PACKAGENAME}
-
 main = putStrLn "It works!"


### PR DESCRIPTION
Importing the package into itself seems like a mistake.  I don't know if
this was intentional, but with this import I got compilation errors
during `cabal run`. Removing this import fixes those issues.
