### PR TITLE
Create empty commit at root

### DIFF
--- a/huspenders
+++ b/huspenders
@@ -47,6 +47,8 @@ git_init() {
 cabal.sandbox.config
 dist/
 GITIGNORE
+
+  git commit --allow-empty --message "Initial Commit"
 }
 
 install_and_precompile(){

--- a/huspenders
+++ b/huspenders
@@ -48,7 +48,7 @@ cabal.sandbox.config
 dist/
 GITIGNORE
 
-  git commit --allow-empty --message "Initial Commit"
+  git commit --all --message "Initial Commit"
 }
 
 install_and_precompile(){


### PR DESCRIPTION
When creating a new project, it's kinda nice to have an empty root
commit. That means you go into a repo that's fully set up, but you can
begin crafting small commits right away, without having to worry about
what the first commit should look like.
